### PR TITLE
feat: add github actions workflow for multi-platform docker builds

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,36 @@
+name: Docker Image Build
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and Push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/your-lastfm:latest
+            ${{ secrets.DOCKERHUB_USERNAME }}/your-lastfm:${{ github.sha }}


### PR DESCRIPTION
I added an automated CI/CD pipeline to build and push Docker images to the Docker Hub. I also added multi-architecture support since you were previously only building for amd64 and not arm64. So every time you make a new release of a tag, it gets build and pushed to Docker Hub.

!! Repository Secrets !!
To enable this pipeline, you need to add two secrets in **Settings > Secrets and variables > Actions > New repository secret**:
`DOCKERHUB_USERNAME`: Your Docker Hub username
`DOCKERHUB_TOKEN`: A Personal Access Token ([info here](https://docs.docker.com/security/access-tokens/)) generated from your Docker hub account
If you do not add those, the pipeline will not work. 