### PR TITLE
Redact Last.fm API key from all error logs

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -17,7 +17,7 @@ const { importScrobbleCSV } = require("./services/importScrobbleCSV");
 const { exportScrobbleCSV } = require("./services/exportScrobbleCSV");
 const { ensureTrackDuration } = require("./services/trackDurationCache");
 const { fetchWithRetry } = require("./utils/fetchRetry");
-const { sanitizeAxiosConfig } = require("./utils/sanitizeAxios");
+const { sanitizeError } = require("./utils/sanitizeAxios");
 
 
 const app = express();
@@ -224,11 +224,7 @@ app.get("/api/recent-scrobbles", async (req, res) => {
     });
 
   } catch (err) {
-    console.error("[recent-scrobbles ERROR]", {
-      message: err.message,
-      status: err.response?.status,
-      config: sanitizeAxiosConfig(err.config)
-    });
+    console.error("[recent-scrobbles ERROR]", sanitizeError(err));
 
     res.status(500).json({ error: "Failed to fetch recent scrobbles" });
   }

--- a/src/services/lastfm-album.js
+++ b/src/services/lastfm-album.js
@@ -1,7 +1,7 @@
 const axios = require("axios");
 require("dotenv").config();
 const { fetchWithRetry } = require("../utils/fetchRetry");
-const { sanitizeAxiosConfig } = require("../utils/sanitizeAxios");
+const { sanitizeError } = require("../utils/sanitizeAxios");
 
 
 const LASTFM_URL = "https://ws.audioscrobbler.com/2.0/";
@@ -29,7 +29,7 @@ async function getAlbumImage(artist, album) {
   } catch (err) {
     console.warn(
       `⚠️ [Last.fm] Album image failed: ${artist} - ${album}`,
-      sanitizeAxiosConfig(err.config)
+      sanitizeError(err)
     );
     return null;
   }

--- a/src/sync.js
+++ b/src/sync.js
@@ -2,7 +2,7 @@ require("dotenv").config();
 const axios = require("axios");
 const db = require("./db");
 const { fetchWithRetry } = require("./utils/fetchRetry");
-const { sanitizeAxiosConfig } = require("./utils/sanitizeAxios");
+const { sanitizeAxiosConfig, sanitizeError } = require("./utils/sanitizeAxios");
 
 const CONFIG = {
   API_URL: "https://ws.audioscrobbler.com/2.0/",
@@ -66,7 +66,7 @@ async function fetchLastfmPage(page) {
   } catch (err) {
     console.error(
       "[Last.fm sync error]",
-      sanitizeAxiosConfig(err.config)
+      sanitizeError(err)
     );
     throw err;
   }

--- a/src/utils/sanitizeAxios.js
+++ b/src/utils/sanitizeAxios.js
@@ -1,8 +1,9 @@
 function sanitizeAxiosConfig(config) {
   if (!config) return config;
 
+  // Redact API key from params
   if (config.params?.api_key) {
-    return {
+    config = {
       ...config,
       params: {
         ...config.params,
@@ -11,6 +12,41 @@ function sanitizeAxiosConfig(config) {
     };
   }
 
+  // Redact API key from URL if present
+  if (config.url) {
+    config.url = config.url.replace(
+      /api_key=[^&]*/g,
+      'api_key=***REDACTED***'
+    );
+  }
+
   return config;
 }
-module.exports = { sanitizeAxiosConfig };
+
+function sanitizeError(error) {
+  if (!error) return error;
+
+  const sanitized = { ...error };
+
+  // Redact from error message
+  if (sanitized.message) {
+    sanitized.message = sanitized.message.replace(
+      /api_key=[^&\s]*/g,
+      'api_key=***REDACTED***'
+    );
+  }
+
+  // Redact from config
+  if (sanitized.config) {
+    sanitized.config = sanitizeAxiosConfig(sanitized.config);
+  }
+
+  // Redact from response
+  if (sanitized.response?.config) {
+    sanitized.response.config = sanitizeAxiosConfig(sanitized.response.config);
+  }
+
+  return sanitized;
+}
+
+module.exports = { sanitizeAxiosConfig, sanitizeError };


### PR DESCRIPTION
- Enhanced sanitizeAxiosConfig to redact API keys from URLs and params
- Added sanitizeError function for comprehensive error sanitization
- Updated error handlers in sync.js, lastfm-album.js, and api.js to use the new sanitizeError function
- Ensures API keys are never exposed in logs regardless of error type