### PR TITLE
Improve Last.fm API retry strategy with exponential backoff

### DIFF
--- a/src/utils/fetchRetry.js
+++ b/src/utils/fetchRetry.js
@@ -1,15 +1,16 @@
-async function fetchWithRetry(fn, retries = 5, delay = 2000) {
+async function fetchWithRetry(fn, retries = 6, delay = 1000) {
   try {
     return await fn();
   } catch (err) {
     const status = err.response?.status;
 
     if (retries > 0 && (status === 500 || status === 502 || status === 503)) {
+      const delaySeconds = Math.round(delay / 1000);
       console.warn(
-        `⚠️ Last.fm temporary error (${status}). Retrying in ${delay}ms... (${retries} retries left)`
+        `⚠️ Last.fm temporary error (${status}). Retrying in ${delaySeconds}s... (${retries} retries left)`
       );
       await new Promise(r => setTimeout(r, delay));
-      return fetchWithRetry(fn, retries - 1, delay * 1.5);
+      return fetchWithRetry(fn, retries - 1, delay * 2);
     }
 
     throw err;


### PR DESCRIPTION
- Increase retries from 5 to 6 (7 total requests)
- Use 2x exponential backoff instead of 1.5x multiplier
- Reduce initial delay from 2s to 1s, allowing faster recovery attempts
- Retry delays now: 1s → 2s → 4s → 8s → 16s → 32s (max)
- Improve log messaging to show delay in seconds

This addresses Last.fm API instability during long pagination runs by giving the backend more time and opportunities to recover between retries.

resolve #23 