### PR TITLE
Ugprade to NodeJS 24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-slim
+FROM node:24-slim
 
 RUN apt-get update && apt-get install -y sqlite3 && rm -rf /var/lib/apt/lists/*
 RUN npm install pm2 -g


### PR DESCRIPTION
NodeJS 20 will be EOL soon in May 2026.

I don't really see a reason to stay on 20 for now.