### PR TITLE
Handle SIGINT correctly

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,4 +8,4 @@ node src/initial-sync.js
 
 echo "🚀 Starting services (API + CRON)..."
 pm2 start src/api.js --name "web-api"
-pm2-runtime start src/cron.js --name "sync-cron"
+exec pm2-runtime start src/cron.js --name "sync-cron"


### PR DESCRIPTION
Instead of spawning pm2-runtime as a child process, the shell process itself becomes pm2-runtime, which is important for proper signal handling (SIGTERM, SIGINT, etc.).

Fixes ctrl+c not working when running container standalone, e.g. with docker run.