### PR TITLE
Fix numbers formatting

### DIFF
--- a/public/js/summary.js
+++ b/public/js/summary.js
@@ -4,7 +4,7 @@ import { buildQuery } from "./filters.js";
 export async function loadSummary() {
   const data = await fetchJSON("/api/summary" + buildQuery());
 
-  document.getElementById("hours").textContent = `${data.totalMinutes}`;
-  document.getElementById("plays").textContent = data.totalPlays;
+  document.getElementById("hours").textContent = data.totalMinutes.toLocaleString();
+  document.getElementById("plays").textContent = data.totalPlays.toLocaleString();
   document.getElementById("avg").textContent = data.avgPerDay;
 }

--- a/public/js/topSongs.js
+++ b/public/js/topSongs.js
@@ -9,8 +9,13 @@ export async function loadTopSongs() {
   container.innerHTML = "";
 
   data.forEach((row, i) => {
-    const minutes = Math.floor(row.total_seconds / 60);
-    const seconds = row.total_seconds % 60;
+    const totalSec = row.total_seconds;
+    const hours = Math.floor(totalSec / 3600);
+    const minutes = Math.floor((totalSec % 3600) / 60);
+    const seconds = totalSec % 60;
+    const time = hours > 0
+      ? `${hours}:${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`
+      : `${minutes}:${String(seconds).padStart(2, "0")}`;
 
     container.innerHTML += `
       <div class="top-song-row">
@@ -30,7 +35,7 @@ export async function loadTopSongs() {
         </div>
 
         <span>${row.plays}</span>
-        <span>${minutes}:${String(seconds).padStart(2, "0")}</span>
+        <span>${time}</span>
       </div>
     `;
   });


### PR DESCRIPTION
## Fix top songs total time format

- Display total play time as h:mm:ss instead of raw minutes when total exceeds one hour

## Add thousand separators to dashboard stats

- Format minutes listened and songs played with locale-aware thousand separators via `.toLocaleString()`

Before:
<img width="1505" height="936" alt="Screenshot 2026-04-03 at 23 14 41" src="https://github.com/user-attachments/assets/aa2d7ef0-5542-487c-8632-56eb892b4157" />

After:
<img width="1508" height="939" alt="Screenshot 2026-04-03 at 23 15 37" src="https://github.com/user-attachments/assets/b7ea70dd-4366-4d9b-8d1f-aba76b8770c2" />
